### PR TITLE
Allow one space between the karma grantee's name and the ++

### DIFF
--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -104,7 +104,7 @@ module Lita::Handlers::Karma
 
     def define_dynamic_routes(pattern)
       self.class.route(
-        %r{(#{pattern})\+\+#{token_terminator.source}},
+        %r{(#{pattern}) {0,1}\+\+#{token_terminator.source}},
         :increment,
         help: { t("help.increment_key") => t("help.increment_value") }
       )

--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -110,13 +110,13 @@ module Lita::Handlers::Karma
       )
 
       self.class.route(
-        %r{(#{pattern})--#{token_terminator.source}},
+        %r{(#{pattern}) {0,1}--#{token_terminator.source}},
         :decrement,
         help: { t("help.decrement_key") => t("help.decrement_value") }
       )
 
       self.class.route(
-        %r{(#{pattern})~~#{token_terminator.source}},
+        %r{(#{pattern}) {0,1}~~#{token_terminator.source}},
         :check,
         help: { t("help.check_key") => t("help.check_value") }
       )

--- a/spec/lita/handlers/karma/chat_spec.rb
+++ b/spec/lita/handlers/karma/chat_spec.rb
@@ -19,7 +19,9 @@ describe Lita::Handlers::Karma::Chat, lita_handler: true do
   it { is_expected.to route("foo++ bar").to(:increment) }
   it { is_expected.to route("foo ++ bar").to(:increment) }
   it { is_expected.to route("foo-- bar").to(:decrement) }
+  it { is_expected.to route("foo -- bar").to(:decrement) }
   it { is_expected.to route("foo~~").to(:check) }
+  it { is_expected.to route("foo ~~").to(:check) }
   it { is_expected.to route_command("karma best").to(:list_best) }
   it { is_expected.to route_command("karma worst").to(:list_worst) }
   it { is_expected.to route_command("karma modified foo").to(:modified) }
@@ -33,6 +35,8 @@ describe Lita::Handlers::Karma::Chat, lita_handler: true do
   it { is_expected.not_to route("-----").to(:decrement) }
   it { is_expected.not_to route("foo++bar").to(:increment) }
   it { is_expected.not_to route("foo--bar").to(:decrement) }
+  it { is_expected.not_to route("foo ++bar").to(:increment) }
+  it { is_expected.not_to route("foo --bar").to(:decrement) }
 
   describe "#increment" do
     it "increases the term's score by one and says the new score" do

--- a/spec/lita/handlers/karma/chat_spec.rb
+++ b/spec/lita/handlers/karma/chat_spec.rb
@@ -14,8 +14,10 @@ describe Lita::Handlers::Karma::Chat, lita_handler: true do
   end
 
   it { is_expected.to route("foo++").to(:increment) }
+  it { is_expected.to route("foo ++").to(:increment) }
   it { is_expected.to route("foo--").to(:decrement) }
   it { is_expected.to route("foo++ bar").to(:increment) }
+  it { is_expected.to route("foo ++ bar").to(:increment) }
   it { is_expected.to route("foo-- bar").to(:decrement) }
   it { is_expected.to route("foo~~").to(:check) }
   it { is_expected.to route_command("karma best").to(:list_best) }


### PR DESCRIPTION
**Disclaimer:** I don't have an instance of Lita running to test this properly.

I essentially updated the regex to allow for 0 or 1 space characters after the karma receiver and before the ++. Then I added a couple of tests to make sure it works.

I also set the PR to this `my-fixes` branch as it is the one referenced in the [changebot gemfile](https://github.com/change/changebot/blob/master/Gemfile#L16).
